### PR TITLE
Fix arguments order

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ class CustomError extends BaseError {}
 try {
   throw new Error('pow')
 } catch (_err) {
-  const err = CustomError.wrap('caught error', _err)
+  const err = CustomError.wrap(_err, 'caught error')
   console.log(err.stack)
   // CustomError: caught error
   //     anonymous (filename:8:17)


### PR DESCRIPTION
According to the source code, the error must be the first argument, then the message string follows.

https://github.com/tjmehta/baseerr/blob/e3a370ef5f91fa722fe428a2d2cc5b877d400599/src/index.ts#L44-L48